### PR TITLE
fix: notification server based on config

### DIFF
--- a/quickshell/nucleus-shell/services/NotifServer.qml
+++ b/quickshell/nucleus-shell/services/NotifServer.qml
@@ -5,7 +5,7 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Notifications
 import QtQuick
-import "root:/config"
+import qs.config
 
 // from github.com/end-4/dots-hyprland with modifications
 


### PR DESCRIPTION
Currently if we disable notification in the config, it doesn't disable notification server, what prevents us to use another notification app. This fix won't enable notification server if notification in the settings are disabled