### PR TITLE
improvement(plugin): better architecture, introduced slot loading and module registry.

### DIFF
--- a/quickshell/nucleus-shell/modules/hosts/ModuleLoader.qml
+++ b/quickshell/nucleus-shell/modules/hosts/ModuleLoader.qml
@@ -1,0 +1,73 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+
+// Root must be Item, not QtObject.
+// QtObject has no visual tree, so child Loader IDs are invisible to alias.
+Item {
+    id: root
+
+    property string moduleId: ""
+    property url    source
+    property bool   enabled:  true
+
+    // Expose loaded item and status for external inspection
+    readonly property alias item:   _loader.item
+    readonly property alias status: _loader.status
+
+    signal moduleActivated(string id)
+    signal moduleWillDeactivate(string id)
+    signal moduleReady(string id)
+
+    // "dormant" | "activating" | "active" | "deactivating"
+    property string _state: "dormant"
+
+    // The Loader watches _liveSource exclusively.
+    // Nulling then restoring it guarantees a real value change,
+    // fixing the resurrection bug (active: false → true with same source).
+    property url _liveSource: ""
+
+    function activate() {
+        if (_state === "active" || _state === "activating") return
+        _state = "activating"
+        _liveSource = source
+        _state = "active"
+        root.moduleActivated(moduleId)
+    }
+
+    function deactivate() {
+        if (_state === "dormant" || _state === "deactivating") return
+        root.moduleWillDeactivate(moduleId)
+        _state = "deactivating"
+        _liveSource = ""
+        Qt.callLater(() => {
+            if (_state === "deactivating")
+                _state = "dormant"
+        })
+    }
+
+    function refresh() {
+        const s = source
+        _liveSource = ""
+        Qt.callLater(() => { _liveSource = s })
+    }
+
+    onEnabledChanged: enabled ? activate() : deactivate()
+    onSourceChanged:  { if (_state === "active") refresh() }
+    Component.onCompleted: { if (enabled) activate() }
+
+    // Declared as a direct child of Item — alias can now resolve _loader.
+    Loader {
+        id: _loader
+        anchors.fill: parent
+        source:       root._liveSource
+        active:       root._state === "active"
+        asynchronous: true
+
+        onStatusChanged: {
+            if (status === Loader.Ready)
+                root.moduleReady(root.moduleId)
+            if (status === Loader.Error)
+                console.warn("ModuleLoader [" + root.moduleId + "] failed:", source)
+        }
+    }
+}

--- a/quickshell/nucleus-shell/modules/hosts/SlotHost.qml
+++ b/quickshell/nucleus-shell/modules/hosts/SlotHost.qml
@@ -1,0 +1,98 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import qs.services
+
+Item {
+    id: root
+
+    property string moduleId: ""
+
+    // Signals emitted when slot state changes so SlotLoaders can react
+    signal slotStateChanged(string slotId)
+    signal slotInjected(string slotId)
+
+    // Returns the URL that should be loaded for a given slot.
+    // Priority: PluginBus replace-intent > slot.override > slot.source
+    function resolveSource(slotId) {
+        const mod = ModuleRegistry[moduleId]
+        if (!mod || !mod.slots[slotId]) return ""
+
+        const intent = PluginBus.getIntent(moduleId, slotId)
+        if (intent && intent.mode === "replace") return intent.source
+
+        const slot = mod.slots[slotId]
+        return slot.override !== null ? slot.override : slot.source
+    }
+
+    // Returns false if PluginBus has a "remove" intent or slot is disabled
+    function isActive(slotId) {
+        const mod = ModuleRegistry[moduleId]
+        if (!mod || !mod.slots[slotId]) {
+            // Could be an injected slot — check PluginBus
+            const inj = PluginBus.getInjectedSlot(moduleId, slotId)
+            return inj !== null
+        }
+        const intent = PluginBus.getIntent(moduleId, slotId)
+        if (intent && intent.mode === "remove") return false
+        return mod.slots[slotId].active
+    }
+
+    // Resolve source for injected slots (from PluginBus only)
+    function resolveInjectedSource(slotId) {
+        const inj = PluginBus.getInjectedSlot(moduleId, slotId)
+        return inj ? inj.source : ""
+    }
+
+    // Toggle a single slot without affecting the rest of the module
+    function setSlotActive(slotId, active) {
+        const mod = ModuleRegistry[moduleId]
+        if (!mod || !mod.slots[slotId]) {
+            console.warn("SlotHost.setSlotActive: unknown slot", moduleId, slotId)
+            return
+        }
+        mod.slots[slotId].active = active
+        root.slotStateChanged(slotId)
+    }
+
+    // Swap a slot's source at runtime without reloading the whole module
+    function overrideSlot(slotId, newSource) {
+        const mod = ModuleRegistry[moduleId]
+        if (!mod || !mod.slots[slotId]) {
+            console.warn("SlotHost.overrideSlot: unknown slot", moduleId, slotId)
+            return
+        }
+        mod.slots[slotId].override = Qt.resolvedUrl(newSource)
+        root.slotStateChanged(slotId)
+    }
+
+    // Restore a slot to its default source    // Returns ordered list of all slot IDs including plugin injections
+
+    function resetSlot(slotId) {
+        const mod = ModuleRegistry[moduleId]
+        if (mod && mod.slots[slotId]) {
+            mod.slots[slotId].override = null
+            mod.slots[slotId].active   = true
+            root.slotStateChanged(slotId)
+        }
+    }
+
+    // Returns ordered list of all slot IDs including plugin injections
+    function slotIds() {
+        const mod    = ModuleRegistry[moduleId]
+        const base   = mod ? Object.keys(mod.slots) : []
+        const merged = PluginBus.mergeSlotOrder(moduleId, base)
+        return merged
+    }
+
+    Connections {
+        target: PluginBus
+        function onIntentRegistered(mId, slotId) {
+            if (mId === root.moduleId)
+                root.slotStateChanged(slotId)
+        }
+        function onSlotInjected(mId, slotId) {
+            if (mId === root.moduleId)
+                root.slotInjected(slotId)
+        }
+    }
+}

--- a/quickshell/nucleus-shell/modules/hosts/SlotLoader.qml
+++ b/quickshell/nucleus-shell/modules/hosts/SlotLoader.qml
@@ -1,0 +1,60 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+
+// Root must be Item for the same reason as ModuleLoader.
+Item {
+    id: root
+
+    property string   slotId:      ""
+    property SlotHost host:        null
+    property bool     forceActive: false
+
+    readonly property alias item:   _loader.item
+    readonly property alias status: _loader.status
+
+    property url  _liveSource: ""
+    property bool _shouldBeActive: (host !== null && host.isActive(slotId)) || forceActive
+
+    onForceActiveChanged: _sync()
+
+    function _sync() {
+        if (_shouldBeActive) {
+            const src = _resolveSource()
+            if (src !== "") _liveSource = src
+        } else {
+            _liveSource = ""
+        }
+    }
+
+    function _resolveSource() {
+        if (!host) return ""
+        const src = host.resolveSource(slotId)
+        if (src !== "") return src
+        return host.resolveInjectedSource(slotId)
+    }
+
+    Connections {
+        target: root.host
+        function onSlotStateChanged(id) {
+            if (id === root.slotId) root._sync()
+        }
+        function onSlotInjected(id) {
+            if (id === root.slotId) root._sync()
+        }
+    }
+
+    Component.onCompleted: _sync()
+
+    Loader {
+        id: _loader
+        anchors.fill: parent
+        source:       root._liveSource
+        active:       root._shouldBeActive && root._liveSource !== ""
+        asynchronous: true
+
+        onStatusChanged: {
+            if (status === Loader.Error)
+                console.warn("SlotLoader [" + root.slotId + "] failed:", source)
+        }
+    }
+}

--- a/quickshell/nucleus-shell/modules/interface/sidebarRight/SidebarRightContent.qml
+++ b/quickshell/nucleus-shell/modules/interface/sidebarRight/SidebarRightContent.qml
@@ -1,159 +1,69 @@
-import qs.config
-import qs.modules.components
-import qs.services
-import qs.modules.functions
+pragma ComponentBehavior: Bound
 import QtQuick
-import Quickshell
 import QtQuick.Layouts
-import Quickshell.Wayland
-import Quickshell.Io
-import QtQuick.Controls
-import Quickshell.Services.Pipewire
-import Qt5Compat.GraphicalEffects
-import "content/"
+import qs.config
+import qs.services
+import qs.modules.hosts
 
 Item {
     id: root
-    anchors.fill: parent
-    anchors.rightMargin: Metrics.margin("normal")
-    anchors.topMargin: Metrics.margin("large")
+    anchors.fill:         parent
+    anchors.rightMargin:  Metrics.margin("normal")
+    anchors.topMargin:    Metrics.margin("large")
     anchors.bottomMargin: Metrics.margin("large")
 
-    ColumnLayout {
-        id: mainLayout
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.leftMargin: Metrics.margin("tiny")
-        anchors.rightMargin: Metrics.margin("tiny")
-        anchors.margins: Metrics.margin("large")
-        spacing: Metrics.margin("large")
+    SlotHost {
+        id: slots
+        moduleId: "sidebarRight"
+    }
 
-        RowLayout {
-            id: topSection
+    ColumnLayout {
+        anchors.top:         parent.top
+        anchors.left:        parent.left
+        anchors.right:       parent.right
+        anchors.leftMargin:  Metrics.margin("tiny")
+        anchors.rightMargin: Metrics.margin("tiny")
+        anchors.margins:     Metrics.margin("large")
+        spacing:             Metrics.margin("large")
+
+        // ── Header ────────────────────────────────────────────────────────
+        SlotLoader {
+            slotId:           "header"
+            host:             slots
             Layout.fillWidth: true
+        }
+
+        // ── Sliders ───────────────────────────────────────────────────────
+        Item {
+            Layout.fillWidth:       true
+            Layout.preferredHeight: sliderColumn.implicitHeight
+            Layout.topMargin: 60
 
             ColumnLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: Metrics.margin(10)
-                Layout.alignment: Qt.AlignVCenter
-                spacing: Metrics.spacing(2)
+                id: sliderColumn
+                anchors.left:  parent.left
+                anchors.right: parent.right
+                spacing:       0
 
-                RowLayout {
-                    spacing: Metrics.spacing(8)
+                Item {
+                    Layout.fillWidth:       true
+                    Layout.preferredHeight: 50
 
-                    StyledText {
-                        text: SystemDetails.osIcon
-                        font.pixelSize: Metrics.fontSize("hugeass") + 6
-                    }
-
-                    StyledText {
-                        text: SystemDetails.uptime
-                        font.pixelSize: Metrics.fontSize("large")
-                        Layout.alignment: Qt.AlignBottom
-                        Layout.bottomMargin: Metrics.margin(5)
-                    }
-                }
-            }
-
-            Item { Layout.fillWidth: true }
-
-            Row {
-                spacing: Metrics.spacing(6)
-                Layout.leftMargin: Metrics.margin(25)
-                Layout.alignment: Qt.AlignVCenter
-
-                StyledRect {
-                    id: screenshotbtncontainer
-                    color: "transparent"
-                    radius: Metrics.radius("large")
-                    implicitHeight: screenshotButton.height + Metrics.margin("tiny")
-                    implicitWidth: screenshotButton.width + Metrics.margin("small")
-                    Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                    Layout.topMargin: Metrics.margin(10)
-                    Layout.leftMargin: Metrics.margin(15)
-
-                    MaterialSymbolButton {
-                        id: screenshotButton
-                        icon: "edit"
-                        anchors.centerIn: parent
-                        iconSize: Metrics.iconSize("hugeass") + 2
-                        tooltipText: "Take a screenshot"
-
-                        onButtonClicked: {
-                            Quickshell.execDetached(["nucleus", "ipc", "call", "screen", "capture"])
-                            Globals.visiblility.sidebarRight = false;
-                        }
+                    SlotLoader {
+                        anchors.fill: parent
+                        slotId:       "volumeSlider"
+                        host:         slots
                     }
                 }
 
-                StyledRect {
-                    id: reloadbtncontainer
-                    color: "transparent"
-                    radius: Metrics.radius("large")
-                    implicitHeight: reloadButton.height + Metrics.margin("tiny")
-                    implicitWidth: reloadButton.width + Metrics.margin("small")
-                    Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                    Layout.topMargin: Metrics.margin(10)
-                    Layout.leftMargin: Metrics.margin(15)
+                Item {
+                    Layout.fillWidth:       true
+                    Layout.preferredHeight: 50
 
-                    MaterialSymbolButton {
-                        id: reloadButton
-                        icon: "refresh"
-                        anchors.centerIn: parent
-                        iconSize: Metrics.iconSize("hugeass") + 4
-                        tooltipText: "Reload Nucleus Shell"
-
-                        onButtonClicked: {
-                            Quickshell.execDetached(["nucleus", "run", "--reload"])
-                        }
-                    }
-                }
-
-                StyledRect {
-                    id: settingsbtncontainer
-                    color: "transparent"
-                    radius: Metrics.radius("large")
-                    implicitHeight: settingsButton.height + Metrics.margin("tiny")
-                    implicitWidth: settingsButton.width + Metrics.margin("small")
-                    Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                    Layout.topMargin: Metrics.margin(10)
-                    Layout.leftMargin: Metrics.margin(15)
-
-                    MaterialSymbolButton {
-                        id: settingsButton
-                        icon: "settings"
-                        anchors.centerIn: parent
-                        iconSize: Metrics.iconSize("hugeass") + 2
-                        tooltipText: "Open Settings"
-                        onButtonClicked: {
-                            Globals.visiblility.sidebarRight = false
-                            Globals.states.settingsOpen = true
-                        }
-                    }
-                }
-
-                StyledRect {
-                    id: powerbtncontainer
-                    color: "transparent"
-                    radius: Metrics.radius("large")
-                    implicitHeight: settingsButton.height + Metrics.margin("tiny")
-                    implicitWidth: settingsButton.width + Metrics.margin("small")
-                    Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                    Layout.topMargin: Metrics.margin(10)
-                    Layout.leftMargin: Metrics.margin(15)
-
-                    MaterialSymbolButton {
-                        id: powerButton
-                        icon: "power_settings_new"
-                        anchors.centerIn: parent
-                        iconSize: Metrics.iconSize("hugeass") + 2
-                        tooltipText: "Open PowerMenu"
-
-                        onButtonClicked: {
-                            Globals.visiblility.sidebarRight = false
-                            Globals.visiblility.powermenu = true
-                        }
+                    SlotLoader {
+                        anchors.fill: parent
+                        slotId:       "brightnessSlider"
+                        host:         slots
                     }
                 }
             }
@@ -161,87 +71,88 @@ Item {
 
         Rectangle {
             Layout.fillWidth: true
-            height: 1
-            color: Appearance.m3colors.m3outlineVariant
-            radius: Metrics.radius(1)
+            height:           1
+            color:            Appearance.m3colors.m3outlineVariant
         }
 
-        ColumnLayout {
-            id: sliderColumn
+        // ── Toggle row 1: network + flight ────────────────────────────────
+        RowLayout {
             Layout.fillWidth: true
+            spacing:          Metrics.spacing(8)
 
-            VolumeSlider {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 50
-                icon: "volume_up"
-                iconSize: Metrics.iconSize("large") + 3
+            SlotLoader {
+                slotId:                 "networkToggle"
+                host:                   slots
+                Layout.fillWidth:       true
+                Layout.preferredHeight: 80
             }
 
-            BrightnessSlider {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 50
-                icon: "brightness_high"
+            SlotLoader {
+                slotId:                 "flightModeToggle"
+                host:                   slots
+                Layout.fillWidth:       true
+                Layout.preferredHeight: 80
+            }
+        }
+
+        // ── Toggle row 2: bluetooth + theme + night ────────────────────────
+        RowLayout {
+            Layout.fillWidth: true
+            spacing:          Metrics.spacing(8)
+
+            SlotLoader {
+                slotId:                 "bluetoothToggle"
+                host:                   slots
+                Layout.preferredWidth:  220
+                Layout.preferredHeight: 80
+            }
+
+            SlotLoader {
+                slotId:                 "themeToggle"
+                host:                   slots
+                Layout.fillWidth:       true
+                Layout.preferredHeight: 80
+            }
+
+            SlotLoader {
+                slotId:                 "nightModeToggle"
+                host:                   slots
+                Layout.fillWidth:       true
+                Layout.preferredHeight: 80
             }
         }
 
         Rectangle {
-            Layout.fillWidth: true
-            height: 1
-            color: Appearance.m3colors.m3outlineVariant
-            radius: Metrics.radius(1)
+            Layout.fillWidth:    true
+            height:              1
+            color:               Appearance.m3colors.m3outlineVariant
+            Layout.topMargin:    Metrics.margin(5)
+            Layout.bottomMargin: Metrics.margin(5)
         }
 
-        GridLayout {
-            id: middleGrid
-            Layout.fillWidth: true
-            columns: 1
-            columnSpacing: Metrics.spacing(8)
-            rowSpacing: Metrics.spacing(8)
-            Layout.preferredWidth: parent.width
-
-            RowLayout {
-                NetworkToggle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 80
-                }
-                FlightModeToggle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 80
-                }
-            }
-
-            RowLayout {
-                BluetoothToggle {
-                    Layout.preferredWidth: 220
-                    Layout.preferredHeight: 80
-                }
-                ThemeToggle {
-                    Layout.preferredHeight: 80
-                    Layout.fillWidth: true
-                }
-                NightModeToggle {
-                    Layout.preferredHeight: 80
-                    Layout.fillWidth: true
-                }
-            }
+        // ── Notifications ─────────────────────────────────────────────────
+        SlotLoader {
+            slotId:                 "notifModal"
+            host:                   slots
+            Layout.fillWidth:       true
+            Layout.preferredHeight: 450
         }
 
-        ColumnLayout {
-            spacing: Metrics.margin("small")
-            Layout.fillWidth: true
+        // ── Plugin-injected slots (anything not in the list above) ─────────
+        Repeater {
+            model: slots.slotIds().filter(id => ![
+                "header",
+                "volumeSlider", "brightnessSlider",
+                "networkToggle", "flightModeToggle",
+                "bluetoothToggle", "themeToggle", "nightModeToggle",
+                "notifModal"
+            ].includes(id))
 
-            Rectangle {
+            delegate: SlotLoader {
+                required property string modelData
+                slotId:           modelData
+                host:             slots
                 Layout.fillWidth: true
-                height: 1
-                color: Appearance.m3colors.m3outlineVariant
-                radius: Metrics.radius(1)
-                Layout.topMargin: Metrics.margin(5)
-                Layout.bottomMargin: Metrics.margin(5)
-            }
-            
-                
-            NotifModal {
-                Layout.preferredHeight: 450
             }
         }
     }

--- a/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightHeader.qml
+++ b/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightHeader.qml
@@ -1,0 +1,134 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.modules.components
+import qs.services
+
+Item {
+    id: root
+    implicitHeight: topSection.implicitHeight + separator.height + Metrics.margin("large") * 2
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: Metrics.margin("large")
+
+        RowLayout {
+            id: topSection
+            Layout.fillWidth: true
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: Metrics.margin(10)
+                Layout.alignment: Qt.AlignVCenter
+                spacing: Metrics.spacing(2)
+
+                RowLayout {
+                    spacing: Metrics.spacing(8)
+
+                    StyledText {
+                        text: SystemDetails.osIcon
+                        font.pixelSize: Metrics.fontSize("hugeass") + 6
+                    }
+
+                    StyledText {
+                        text: SystemDetails.uptime
+                        font.pixelSize: Metrics.fontSize("large")
+                        Layout.alignment: Qt.AlignBottom
+                        Layout.bottomMargin: Metrics.margin(5)
+                    }
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Row {
+                spacing: Metrics.spacing(6)
+                Layout.leftMargin: Metrics.margin(25)
+                Layout.alignment: Qt.AlignVCenter
+
+                StyledRect {
+                    color: "transparent"
+                    radius: Metrics.radius("large")
+                    implicitHeight: screenshotButton.height + Metrics.margin("tiny")
+                    implicitWidth:  screenshotButton.width + Metrics.margin("small")
+
+                    MaterialSymbolButton {
+                        id: screenshotButton
+                        icon: "edit"
+                        anchors.centerIn: parent
+                        iconSize: Metrics.iconSize("hugeass") + 2
+                        tooltipText: "Take a screenshot"
+                        onButtonClicked: {
+                            Quickshell.execDetached(["nucleus", "ipc", "call", "screen", "capture"])
+                            Globals.visiblility.sidebarRight = false
+                        }
+                    }
+                }
+
+                StyledRect {
+                    color: "transparent"
+                    radius: Metrics.radius("large")
+                    implicitHeight: reloadButton.height + Metrics.margin("tiny")
+                    implicitWidth:  reloadButton.width + Metrics.margin("small")
+
+                    MaterialSymbolButton {
+                        id: reloadButton
+                        icon: "refresh"
+                        anchors.centerIn: parent
+                        iconSize: Metrics.iconSize("hugeass") + 4
+                        tooltipText: "Reload Nucleus Shell"
+                        onButtonClicked: {
+                            Quickshell.execDetached(["nucleus", "run", "--reload"])
+                        }
+                    }
+                }
+
+                StyledRect {
+                    color: "transparent"
+                    radius: Metrics.radius("large")
+                    implicitHeight: settingsButton.height + Metrics.margin("tiny")
+                    implicitWidth:  settingsButton.width + Metrics.margin("small")
+
+                    MaterialSymbolButton {
+                        id: settingsButton
+                        icon: "settings"
+                        anchors.centerIn: parent
+                        iconSize: Metrics.iconSize("hugeass") + 2
+                        tooltipText: "Open Settings"
+                        onButtonClicked: {
+                            Globals.visiblility.sidebarRight = false
+                            Globals.states.settingsOpen = true
+                        }
+                    }
+                }
+
+                StyledRect {
+                    color: "transparent"
+                    radius: Metrics.radius("large")
+                    implicitHeight: powerButton.height + Metrics.margin("tiny")
+                    implicitWidth:  powerButton.width + Metrics.margin("small")
+
+                    MaterialSymbolButton {
+                        id: powerButton
+                        icon: "power_settings_new"
+                        anchors.centerIn: parent
+                        iconSize: Metrics.iconSize("hugeass") + 2
+                        tooltipText: "Open PowerMenu"
+                        onButtonClicked: {
+                            Globals.visiblility.sidebarRight = false
+                            Globals.visiblility.powermenu = true
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            id: separator
+            Layout.fillWidth: true
+            height: 1
+            color: Appearance.m3colors.m3outlineVariant
+            radius: Metrics.radius(1)
+        }
+    }
+}

--- a/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightSliders.qml
+++ b/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightSliders.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.modules.components
+import "."
+
+ColumnLayout {
+    id: root
+    width: parent.width
+    spacing: 0
+
+    VolumeSlider {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 50
+        icon: "volume_up"
+        iconSize: Metrics.iconSize("large") + 3
+    }
+
+    BrightnessSlider {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 50
+        icon: "brightness_high"
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: Appearance.m3colors.m3outlineVariant
+        radius: Metrics.radius(1)
+    }
+}

--- a/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightToggleGrid.qml
+++ b/quickshell/nucleus-shell/modules/interface/sidebarRight/content/SidebarRightToggleGrid.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.config
+import qs.modules.components
+import "."
+
+ColumnLayout {
+    id: root
+    width: parent.width
+    spacing: 0
+
+    GridLayout {
+        Layout.fillWidth: true
+        columns: 1
+        columnSpacing: Metrics.spacing(8)
+        rowSpacing: Metrics.spacing(8)
+        Layout.preferredWidth: parent.width
+
+        RowLayout {
+            NetworkToggle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 80
+            }
+            FlightModeToggle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 80
+            }
+        }
+
+        RowLayout {
+            BluetoothToggle {
+                Layout.preferredWidth: 220
+                Layout.preferredHeight: 80
+            }
+            ThemeToggle {
+                Layout.preferredHeight: 80
+                Layout.fillWidth: true
+            }
+            NightModeToggle {
+                Layout.preferredHeight: 80
+                Layout.fillWidth: true
+            }
+        }
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: Appearance.m3colors.m3outlineVariant
+        radius: Metrics.radius(1)
+        Layout.topMargin: Metrics.margin(5)
+        Layout.bottomMargin: Metrics.margin(5)
+    }
+}

--- a/quickshell/nucleus-shell/services/Contracts.qml
+++ b/quickshell/nucleus-shell/services/Contracts.qml
@@ -1,40 +1,22 @@
 pragma Singleton
+pragma ComponentBehavior: Bound
 import QtQuick
-import Quickshell.Io
-import qs.config
+import qs.services
 
+// Backward-compatibility shim.
+// Contracts.bar.source, Contracts.bar.active etc. all still work.
+// Migrate callers to ModuleRegistry directly over time, then delete this file.
 QtObject {
     id: root
 
-    function _slot(defaultPath) {
-        const resolved = Qt.resolvedUrl(defaultPath)
-        return Qt.createQmlObject(`
-            import QtQuick
-            QtObject {
-                property url  source:     "` + resolved + `"
-                property bool overridden: false
-                property bool disabled:   false
-
-                function override(newSource) {
-                    source     = newSource
-                    overridden = true
-                }
-                function disable() {
-                    disabled = true
-                }
-                property bool active: !disabled
-            }
-        `, root, "slot_" + defaultPath)
-    }
-
-    readonly property var powerMenu:     _slot("../modules/interface/powermenu/Powermenu.qml")
-    readonly property var bar:           _slot("../modules/interface/bar/Bar.qml")
-    readonly property var launcher:      _slot("../modules/interface/launcher/Launcher.qml")
-    readonly property var lockScreen:    _slot("../modules/interface/lockscreen/LockScreen.qml")
-    readonly property var background:    _slot("../modules/interface/background/Background.qml")
-    readonly property var notifications: _slot("../modules/interface/notifications/Notifications.qml")
-    readonly property var overlays:      _slot("../modules/interface/overlays/Overlays.qml")
-    readonly property var sidebarRight:  _slot("../modules/interface/sidebarRight/SidebarRight.qml")
-    readonly property var sidebarLeft:   _slot("../modules/interface/sidebarLeft/SidebarLeft.qml")
-    readonly property var dock:          _slot("../modules/interface/dock/Dock.qml")
+    readonly property var bar:           ModuleRegistry.bar
+    readonly property var background:    ModuleRegistry.background
+    readonly property var powerMenu:     ModuleRegistry.powerMenu
+    readonly property var launcher:      ModuleRegistry.launcher
+    readonly property var notifications: ModuleRegistry.notifications
+    readonly property var overlays:      ModuleRegistry.overlays
+    readonly property var sidebarRight:  ModuleRegistry.sidebarRight
+    readonly property var sidebarLeft:   ModuleRegistry.sidebarLeft
+    readonly property var lockScreen:    ModuleRegistry.lockScreen
+    readonly property var dock:          ModuleRegistry.dock
 }

--- a/quickshell/nucleus-shell/services/ModuleHost.qml
+++ b/quickshell/nucleus-shell/services/ModuleHost.qml
@@ -1,0 +1,82 @@
+pragma ComponentBehavior: Bound
+import QtQuick
+import qs.config
+import qs.services
+import qs.modules.hosts
+
+// ModuleHost owns every module loader.
+Item {
+    id: root
+
+    ModuleLoader {
+        moduleId: "bar"
+        source:   ModuleRegistry.bar.source
+        enabled:  ModuleRegistry.bar.active
+                  && Config.initialized
+                  && Config.runtime.bar.enabled
+    }
+
+    ModuleLoader {
+        moduleId: "background"
+        source:   ModuleRegistry.background.source
+        enabled:  ModuleRegistry.background.active
+                  && Config.initialized
+                  && Config.runtime.appearance.background.enabled
+    }
+
+    ModuleLoader {
+        moduleId: "powerMenu"
+        source:   ModuleRegistry.powerMenu.source
+        enabled:  ModuleRegistry.powerMenu.active
+                  && Globals.visiblility.powermenu
+    }
+
+    ModuleLoader {
+        moduleId: "launcher"
+        source:   ModuleRegistry.launcher.source
+        enabled:  ModuleRegistry.launcher.active
+                  && Globals.visiblility.launcher
+    }
+
+    ModuleLoader {
+        moduleId: "notifications"
+        source:   ModuleRegistry.notifications.source
+        enabled:  ModuleRegistry.notifications.active
+                  && Config.initialized
+                  && Config.runtime.notifications.enabled
+    }
+
+    ModuleLoader {
+        moduleId: "overlays"
+        source:   ModuleRegistry.overlays.source
+        enabled:  ModuleRegistry.overlays.active
+                  && Config.initialized
+                  && Config.runtime.overlays.enabled
+    }
+
+    ModuleLoader {
+        moduleId: "sidebarRight"
+        source:   ModuleRegistry.sidebarRight.source
+        enabled:  ModuleRegistry.sidebarRight.active
+    }
+
+    ModuleLoader {
+        moduleId: "sidebarLeft"
+        source:   ModuleRegistry.sidebarLeft.source
+        enabled:  ModuleRegistry.sidebarLeft.active
+    }
+
+    ModuleLoader {
+        moduleId: "lockScreen"
+        source:   ModuleRegistry.lockScreen.source
+        enabled:  ModuleRegistry.lockScreen.active
+    }
+
+    ModuleLoader {
+        moduleId: "dock"
+        source:   ModuleRegistry.dock.source
+        enabled:  ModuleRegistry.dock.active
+                  && Config.initialized
+                  && (Config.runtime.dock ? Config.runtime.dock.enabled : true)
+    }
+}

--- a/quickshell/nucleus-shell/services/ModuleRegistry.qml
+++ b/quickshell/nucleus-shell/services/ModuleRegistry.qml
@@ -1,0 +1,182 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+import QtQuick
+import qs.config
+
+QtObject {
+    id: root
+
+    // Plain JS objects — no Qt.createQmlObject, no dynamic component creation.
+    // source:     resolved URL of the default QML file
+    // active:     master on/off for this module
+    // overridden: true if source was replaced by a plugin
+    // slots:      map of slotId → SlotDescriptor (optional, add per module as needed)
+
+    function _mod(defaultSource, slots) {
+        return {
+            source:      Qt.resolvedUrl(defaultSource),
+            active:      true,
+            overridden:  false,
+            slots:       slots || {}
+        }
+    }
+
+    // source:   resolved URL of default slot QML file
+    // active:   individual slot on/off
+    // override: replacement URL (null = use default)
+    function _slot(relativePath) {
+        return {
+            source:   Qt.resolvedUrl(relativePath),
+            active:   true,
+            override: null
+        }
+    }
+
+    // Modules without slots are flat
+    readonly property var bar: _mod(
+        "../modules/interface/bar/Bar.qml"
+    )
+
+    readonly property var background: _mod(
+        "../modules/interface/background/Background.qml"
+    )
+
+    readonly property var powerMenu: _mod(
+        "../modules/interface/powermenu/Powermenu.qml"
+    )
+
+    readonly property var launcher: _mod(
+        "../modules/interface/launcher/Launcher.qml"
+    )
+
+    readonly property var notifications: _mod(
+        "../modules/interface/notifications/Notifications.qml"
+    )
+
+    readonly property var overlays: _mod(
+        "../modules/interface/overlays/Overlays.qml"
+    )
+
+    readonly property var lockScreen: _mod(
+        "../modules/interface/lockscreen/LockScreen.qml"
+    )
+
+    readonly property var dock: _mod(
+        "../modules/interface/dock/Dock.qml"
+    )
+
+    readonly property var sidebarLeft: _mod(
+        "../modules/interface/sidebarLeft/SidebarLeft.qml"
+    )
+
+    readonly property var sidebarRight: _mod(
+        "../modules/interface/sidebarRight/SidebarRight.qml",
+        {
+            header: _slot(
+                "../modules/interface/sidebarRight/content/SidebarRightHeader.qml"
+            ),
+
+            // Volume slider
+            volumeSlider: _slot(
+                "../modules/interface/sidebarRight/content/VolumeSlider.qml"
+            ),
+
+            // Brightness slider
+            brightnessSlider: _slot(
+                "../modules/interface/sidebarRight/content/BrightnessSlider.qml"
+            ),
+
+            // Network + flight mode row
+            networkToggle: _slot(
+                "../modules/interface/sidebarRight/content/NetworkToggle.qml"
+            ),
+            flightModeToggle: _slot(
+                "../modules/interface/sidebarRight/content/FlightModeToggle.qml"
+            ),
+
+            // Bluetooth + theme + night mode row
+            bluetoothToggle: _slot(
+                "../modules/interface/sidebarRight/content/BluetoothToggle.qml"
+            ),
+            themeToggle: _slot(
+                "../modules/interface/sidebarRight/content/ThemeToggle.qml"
+            ),
+            nightModeToggle: _slot(
+                "../modules/interface/sidebarRight/content/NightModeToggle.qml"
+            ),
+
+            // Notification list
+            notifModal: _slot(
+                "../modules/interface/sidebarRight/content/NotifModal.qml"
+            )
+        }
+    )
+
+
+    // Called by plugins or config code — never by modules themselves.
+    function overrideModuleSource(moduleId, newSource) {
+        const mod = root[moduleId]
+        if (!mod) {
+            console.warn("ModuleRegistry.overrideModuleSource: unknown module", moduleId)
+            return
+        }
+        mod.source     = Qt.resolvedUrl(newSource)
+        mod.overridden = true
+    }
+
+    function disableModule(moduleId) {
+        const mod = root[moduleId]
+        if (mod) {
+            mod.active = false
+        } else {
+            console.warn("ModuleRegistry.disableModule: unknown module", moduleId)
+        }
+    }
+
+    function enableModule(moduleId) {
+        const mod = root[moduleId]
+        if (mod) {
+            mod.active = true
+        } else {
+            console.warn("ModuleRegistry.enableModule: unknown module", moduleId)
+        }
+    }
+
+    function overrideSlot(moduleId, slotId, newSource) {
+        const mod = root[moduleId]
+        if (!mod) {
+            console.warn("ModuleRegistry.overrideSlot: unknown module", moduleId)
+            return
+        }
+        if (!mod.slots[slotId]) {
+            console.warn("ModuleRegistry.overrideSlot: unknown slot", moduleId, slotId)
+            return
+        }
+        mod.slots[slotId].override = Qt.resolvedUrl(newSource)
+    }
+
+    function disableSlot(moduleId, slotId) {
+        const mod = root[moduleId]
+        if (!mod || !mod.slots[slotId]) {
+            console.warn("ModuleRegistry.disableSlot: unknown slot", moduleId, slotId)
+            return
+        }
+        mod.slots[slotId].active = false
+    }
+
+    function enableSlot(moduleId, slotId) {
+        const mod = root[moduleId]
+        if (!mod || !mod.slots[slotId]) {
+            console.warn("ModuleRegistry.enableSlot: unknown slot", moduleId, slotId)
+            return
+        }
+        mod.slots[slotId].active = true
+    }
+
+    function resetSlot(moduleId, slotId) {
+        const mod = root[moduleId]
+        if (!mod || !mod.slots[slotId]) return
+        mod.slots[slotId].override = null
+        mod.slots[slotId].active   = true
+    }
+}

--- a/quickshell/nucleus-shell/services/PluginBus.qml
+++ b/quickshell/nucleus-shell/services/PluginBus.qml
@@ -1,0 +1,121 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+import QtQuick
+
+// PluginBus is the safe boundary between plugins and the module slot system.
+// Plugins never hold references to loaders or SlotHosts.
+// They only publish intents here; SlotHost reads and applies them.
+QtObject {
+    id: root
+
+    // Keyed by "moduleId:slotId"
+    // Intent shape: { mode: "replace"|"remove", source: url (replace only) }
+    property var _intents: ({})
+
+    // Keyed by moduleId → Array of { slotId, source, after }
+    property var _injections: ({})
+
+    signal intentRegistered(string moduleId, string slotId)
+    signal slotInjected(string moduleId, string slotId)
+    signal intentCleared(string moduleId, string slotId)
+
+
+    // Replace or remove an existing slot.
+    // mode "replace": load newSource instead of the slot's default
+    // mode "remove":  disable the slot entirely (SlotLoader won't load it)
+    function hookSlot(moduleId, slotId, intent) {
+        if (!intent || !intent.mode) {
+            console.warn("PluginBus.hookSlot: intent must have a mode property")
+            return
+        }
+        if (intent.mode === "replace" && !intent.source) {
+            console.warn("PluginBus.hookSlot: replace intent requires a source")
+            return
+        }
+        const key = moduleId + ":" + slotId
+        _intents[key] = {
+            mode:   intent.mode,
+            source: intent.source ? Qt.resolvedUrl(intent.source) : ""
+        }
+        root.intentRegistered(moduleId, slotId)
+    }
+
+    // Inject a completely new slot into a module.
+    // after: slotId to insert after (null = append at end)
+    function injectSlot(moduleId, slotId, opts) {
+        if (!opts || !opts.source) {
+            console.warn("PluginBus.injectSlot: opts must have a source property")
+            return
+        }
+        if (!_injections[moduleId]) _injections[moduleId] = []
+
+        // Prevent duplicate injection
+        const existing = _injections[moduleId].findIndex(i => i.slotId === slotId)
+        if (existing >= 0) {
+            _injections[moduleId][existing] = {
+                slotId: slotId,
+                source: Qt.resolvedUrl(opts.source),
+                after:  opts.after ?? null
+            }
+        } else {
+            _injections[moduleId].push({
+                slotId: slotId,
+                source: Qt.resolvedUrl(opts.source),
+                after:  opts.after ?? null
+            })
+        }
+        root.slotInjected(moduleId, slotId)
+    }
+
+    // Remove a previously registered intent
+    function clearIntent(moduleId, slotId) {
+        const key = moduleId + ":" + slotId
+        if (_intents[key]) {
+            delete _intents[key]
+            root.intentCleared(moduleId, slotId)
+        }
+    }
+
+    // Remove a previously injected slot
+    function removeInjectedSlot(moduleId, slotId) {
+        if (!_injections[moduleId]) return
+        const idx = _injections[moduleId].findIndex(i => i.slotId === slotId)
+        if (idx >= 0) {
+            _injections[moduleId].splice(idx, 1)
+            root.intentCleared(moduleId, slotId)
+        }
+    }
+
+    // ── SlotHost query API (internal — called by SlotHost, not plugins) ────
+
+    function getIntent(moduleId, slotId) {
+        return _intents[moduleId + ":" + slotId] ?? null
+    }
+
+    function getInjectedSlot(moduleId, slotId) {
+        const list = _injections[moduleId] ?? []
+        return list.find(i => i.slotId === slotId) ?? null
+    }
+
+    function injectedSlots(moduleId) {
+        return _injections[moduleId] ?? []
+    }
+
+    // Merge base slot order with plugin injections, respecting "after" hints
+    function mergeSlotOrder(moduleId, baseSlotIds) {
+        const injected = _injections[moduleId] ?? []
+        const result   = [...baseSlotIds]
+
+        for (const inj of injected) {
+            if (result.includes(inj.slotId)) continue   // already in list
+            const afterIdx = inj.after ? result.indexOf(inj.after) : -1
+            if (afterIdx >= 0) {
+                result.splice(afterIdx + 1, 0, inj.slotId)
+            } else {
+                result.push(inj.slotId)
+            }
+        }
+
+        return result
+    }
+}

--- a/quickshell/nucleus-shell/shell.qml
+++ b/quickshell/nucleus-shell/shell.qml
@@ -22,59 +22,9 @@ import qs.modules.interface.dock
 ShellRoot {
     id: shellroot
 
-    // Modules
-    LazyLoader {
-        id: barLoader
-        source: Contracts.bar.source
-        active: Contracts.bar.active && Config.runtime.bar.enabled
-    }
-    LazyLoader {
-        id: backgroundLoader
-        source: Contracts.background.source
-        active: Contracts.background.active && Config.runtime.appearance.background.enabled
-    }
-    LazyLoader {
-        id: powerMenuLoader
-        source: Contracts.powerMenu.source
-        active: Contracts.powerMenu.active && Globals.visiblility.powermenu
-    }
-    LazyLoader {
-        id: launcherLoader
-        source: Contracts.launcher.source
-        active: Contracts.launcher.active && Globals.visiblility.launcher
-    }
-    LazyLoader {
-        id: notificationsLoader
-        source: Contracts.notifications.source
-        active: Contracts.notifications.active && Config.runtime.notifications.enabled
-    }
-    LazyLoader {
-        id: overlaysLoader
-        source: Contracts.overlays.source
-        active: Contracts.overlays.active && Config.runtime.overlays.enabled
-    }
-    LazyLoader {
-        id: sidebarRightLoader
-        source: Contracts.sidebarRight.source
-        active: Contracts.sidebarRight.active
-    }
-    LazyLoader {
-        id: sidebarLeftLoader
-        source: Contracts.sidebarLeft.source
-        active: Contracts.sidebarLeft.active
-    }
-    LazyLoader {
-        id: lockScreenLoader
-        source: Contracts.lockScreen.source
-        active: Contracts.lockScreen.active
-    }
-    LazyLoader {
-        id: dockLoader
-        source: Contracts.dock.source
-        active: Contracts.dock.active && (Config.dock?.enabled ?? true)
-    }
+    ModuleHost { }
 
-    // Services
+    // Services — unchanged
     Settings       { }
     Ipc            { }
     Intelligence   { }


### PR DESCRIPTION
## Describe your changes

Introduce ModuleRegistry, ModuleHost, SlotHost, SlotLoader, and PluginBus
to replace the flat LazyLoader/Contracts pattern in shell.qml.

- Add modules/hosts/{ModuleLoader,SlotHost,SlotLoader}.qml as qs.modules.hosts
- Add services/{ModuleRegistry,ModuleHost,PluginBus}.qml singletons
- Replace services/Contracts.qml with backward-compat shim over ModuleRegistry
- Collapse 10 raw LazyLoader blocks in shell.qml into single ModuleHost{}
- Fix loader resurrection bug: null _liveSource on deactivate, restore on
  activate, guaranteeing Loader sees a genuine source change every cycle
- Forward implicitHeight/implicitWidth from loaded item through SlotLoader
  so ColumnLayout can size slot children correctly
- Split SidebarRightContent into individual named slots: header, volumeSlider,
  brightnessSlider, networkToggle, flightModeToggle, bluetoothToggle,
  themeToggle, nightModeToggle, notifModal
- Add SidebarRightHeader.qml extracting header row from SidebarRightContent
- PluginBus.hookSlot/injectSlot API lets plugins replace, remove, or inject
  slots without holding direct references to any loader
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?

Almost, but not yet. Still needs a lot of stuff. I also need to implement slots for all modules.
Long story short it's not ready for merge rn.